### PR TITLE
Bump core to 6.4.1, OLF to 1.12.2, diagram to 4.5.1, dynawo to 2.5.1, entsoe to 2.10.1, open-rao to 6.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
     </developers>
 
     <properties>
-        <powsybl-core.version>6.3.2</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.11.0</powsybl-open-loadflow.version>
-        <powsybl-diagram.version>4.4.0</powsybl-diagram.version>
-        <powsybl-dynawo.version>2.4.0</powsybl-dynawo.version>
-        <powsybl-entsoe.version>2.9.0</powsybl-entsoe.version>
-        <powsybl-open-rao.version>5.5.1</powsybl-open-rao.version>
+        <powsybl-core.version>6.4.0</powsybl-core.version>
+        <powsybl-open-loadflow.version>1.12.0</powsybl-open-loadflow.version>
+        <powsybl-diagram.version>4.5.0</powsybl-diagram.version>
+        <powsybl-dynawo.version>2.5.0</powsybl-dynawo.version>
+        <powsybl-entsoe.version>2.10.0</powsybl-entsoe.version>
+        <powsybl-open-rao.version>5.6.0</powsybl-open-rao.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,11 +44,11 @@
 
     <properties>
         <powsybl-core.version>6.4.1</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.12.1</powsybl-open-loadflow.version>
-        <powsybl-diagram.version>4.5.0</powsybl-diagram.version>
-        <powsybl-dynawo.version>2.5.0</powsybl-dynawo.version>
-        <powsybl-entsoe.version>2.10.0</powsybl-entsoe.version>
-        <powsybl-open-rao.version>6.0.0</powsybl-open-rao.version>
+        <powsybl-open-loadflow.version>1.12.2</powsybl-open-loadflow.version>
+        <powsybl-diagram.version>4.5.1</powsybl-diagram.version>
+        <powsybl-dynawo.version>2.5.1</powsybl-dynawo.version>
+        <powsybl-entsoe.version>2.10.1</powsybl-entsoe.version>
+        <powsybl-open-rao.version>6.0.1</powsybl-open-rao.version>
     </properties>
 
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <powsybl-core.version>6.4.0</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.12.0</powsybl-open-loadflow.version>
+        <powsybl-open-loadflow.version>1.12.1</powsybl-open-loadflow.version>
         <powsybl-diagram.version>4.5.0</powsybl-diagram.version>
         <powsybl-dynawo.version>2.5.0</powsybl-dynawo.version>
         <powsybl-entsoe.version>2.10.0</powsybl-entsoe.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,12 @@
     </developers>
 
     <properties>
-        <powsybl-core.version>6.4.0</powsybl-core.version>
+        <powsybl-core.version>6.4.1</powsybl-core.version>
         <powsybl-open-loadflow.version>1.12.1</powsybl-open-loadflow.version>
         <powsybl-diagram.version>4.5.0</powsybl-diagram.version>
         <powsybl-dynawo.version>2.5.0</powsybl-dynawo.version>
         <powsybl-entsoe.version>2.10.0</powsybl-entsoe.version>
-        <powsybl-open-rao.version>5.6.0</powsybl-open-rao.version>
+        <powsybl-open-rao.version>6.0.0</powsybl-open-rao.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependencies update


**What is the current behavior?**
<!-- You can also link to an open issue here -->

- powsybl-core 6.3.2
- powsybl-open-loadflow 1.11.0
- powsybl-diagram 4.4.0
- powsybl-dynawo 2.4.0
- powsybl-entsoe 2.9.0
- powsybl-open-rao 5.5.1


**What is the new behavior (if this is a feature change)?**

- powsybl-core **6.4.1**
- powsybl-open-loadflow **1.12.2**
- powsybl-diagram **4.5.1**
- powsybl-dynawo **2.5.1**
- powsybl-entsoe **2.10.1**
- powsybl-open-rao **6.0.1**
