### PR TITLE
Bump core to 6.6.0, OLF to 1.14.0, diagram to _._._, dynawo to 2.7.0, entsoe to 2.12.0, open-rao to _._._ + parent to v20

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>15</version>
+        <version>20</version>
         <relativePath/>
     </parent>
 
@@ -43,11 +43,11 @@
     </developers>
 
     <properties>
-        <powsybl-core.version>6.5.1</powsybl-core.version>
-        <powsybl-open-loadflow.version>1.13.2</powsybl-open-loadflow.version>
+        <powsybl-core.version>6.6.0</powsybl-core.version>
+        <powsybl-open-loadflow.version>1.14.0</powsybl-open-loadflow.version>
         <powsybl-diagram.version>4.6.2</powsybl-diagram.version>
-        <powsybl-dynawo.version>2.6.0</powsybl-dynawo.version>
-        <powsybl-entsoe.version>2.11.0</powsybl-entsoe.version>
+        <powsybl-dynawo.version>2.7.0</powsybl-dynawo.version>
+        <powsybl-entsoe.version>2.12.0</powsybl-entsoe.version>
         <powsybl-open-rao.version>6.1.2</powsybl-open-rao.version>
     </properties>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependencies update


**What is the current behavior?**
<!-- You can also link to an open issue here -->

- powsybl-core 6.5.1
- powsybl-open-loadflow 1.13.2
- powsybl-diagram 4.6.2
- powsybl-dynawo 2.6.0
- powsybl-entsoe 2.11.0
- powsybl-open-rao 6.1.2

\+ powsybl-parent v15 (build dependency)

<br/>

**What is the new behavior (if this is a feature change)?**

- powsybl-core **6.6.0**
- powsybl-open-loadflow **1.14.0**
- powsybl-diagram **_._._**
- powsybl-dynawo **2.7.0**
- powsybl-entsoe **2.12.0**
- powsybl-open-rao **_._._**

\+  powsybl-parent **v20** (build dependency)
