### PR TITLE
Restore powsybl-parent 20 (21+ versions are for Java 21)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>com.powsybl</groupId>
         <artifactId>powsybl-parent</artifactId>
-        <version>22</version>
+        <version>20</version>
         <relativePath/>
     </parent>
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependency update / bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Uses powsybl-parent 22


**What is the new behavior (if this is a feature change)?**
Uses powsybl-parent **20**


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [X] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->

- `powsybl-parent` v21 and higher are for Java 21.
- For now, PowSyBl is still using Java 17 (Java 21 version is expected for September 2025).
