### PR TITLE
Bump core to 6.8.1, OFL to 1.16.0, diagram to 4.9.0, dynawo to 2.9.0, entsoe to 2.14.0, open-rao to 6.6.0 and parent to 20.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     <properties>
         <powsybl-core.version>6.8.1</powsybl-core.version>
         <powsybl-open-loadflow.version>1.16.0</powsybl-open-loadflow.version>
-        <powsybl-diagram.version>4.8.1</powsybl-diagram.version>
+        <powsybl-diagram.version>4.9.0</powsybl-diagram.version>
         <powsybl-dynawo.version>2.9.0</powsybl-dynawo.version>
         <powsybl-entsoe.version>2.14.0</powsybl-entsoe.version>
         <powsybl-open-rao.version>6.6.0</powsybl-open-rao.version>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [X] The commit message follows our guidelines


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Dependencies update


**What is the current behavior?**
<!-- You can also link to an open issue here -->

- powsybl-core 6.7.2
- powsybl-open-loadflow 1.15.2
- powsybl-diagram 4.8.1
- powsybl-dynawo 2.8.2
- powsybl-entsoe 2.13.1
- powsybl-open-rao 6.4.1
- powsybl-parent 20

<br/>

**What is the new behavior (if this is a feature change)?**

- powsybl-core **6.8.1**
- powsybl-open-loadflow **1.16.0**
- powsybl-diagram **4.9.0**
- powsybl-dynawo **2.9.0**
- powsybl-entsoe **2.14.0**
- powsybl-open-rao **6.6.0**
- powsybl-parent **20.2**

